### PR TITLE
Organize recordings into per-tag folders

### DIFF
--- a/data_collect/plot_trajectories.py
+++ b/data_collect/plot_trajectories.py
@@ -3,7 +3,7 @@
 """
 plot_trajectories.py
 --------------------
-读取 data_record/pos_*.npy → 动画播放 + 最终保存一张静态图
+读取 data_record/*/pos.npy → 动画播放 + 最终保存一张静态图
 """
 
 import glob, os, numpy as np, matplotlib.pyplot as plt
@@ -11,9 +11,9 @@ from matplotlib.animation import FuncAnimation
 
 # -------- 读取所有数据 --------
 DATA_DIR = 'data_record'
-files = sorted(glob.glob(os.path.join(DATA_DIR, 'pos_*.npy')))
+files = sorted(glob.glob(os.path.join(DATA_DIR, '*/pos.npy')))
 if not files:
-    raise FileNotFoundError("No pos_*.npy found in data_record/. Run the recorder first.")
+    raise FileNotFoundError("No */pos.npy found in data_record/. Run the recorder first.")
 
 trajectories = [np.load(f)[:, :3] for f in files]   # 仅取 X Y Z
 max_len      = max(t.shape[0] for t in trajectories)

--- a/data_collect/record_and_teleop.py
+++ b/data_collect/record_and_teleop.py
@@ -16,7 +16,7 @@ from arm_kinova import Arm, LINEAR, ANG, GRIP, HOME_KEY   # 复用封装
 HOME_POSE   = [0.213, -0.256, 0.508, 1.651, 1.115, 0.122]
 LIN_VEL     = 0.8          # m/s  (≈4 cm/s)
 ANG_VEL     = 0.30          # rad/s(≈17°/s)
-SAVE_DIR    = 'data_record'; os.makedirs(f'{SAVE_DIR}/color', exist_ok=True); os.makedirs(f'{SAVE_DIR}/depth', exist_ok=True)
+SAVE_DIR    = 'data_record'; os.makedirs(SAVE_DIR, exist_ok=True)
 REC_HZ      = 30
 PUB_HZ      = 100           # 必须 100 Hz :contentReference[oaicite:1]{index=1}
 CAM1_SN, CAM2_SN = "243122075526", "243222073031"
@@ -50,8 +50,12 @@ pipe1, pipe2 = cam(CAM1_SN), cam(CAM2_SN)
 class Recorder(threading.Thread):
     def __init__(self, tag, arm):
         super().__init__(daemon=True)
-        self.tag, self.arm = tag, arm; self.stop_evt = threading.Event()
+        self.tag, self.arm = tag, arm
+        self.stop_evt = threading.Event()
         self.pose, self.grip = [], []
+        self.base = os.path.join(SAVE_DIR, self.tag)
+        os.makedirs(os.path.join(self.base, 'color'), exist_ok=True)
+        os.makedirs(os.path.join(self.base, 'depth'), exist_ok=True)
     def run(self):
         idx, period = 0, 1/REC_HZ
         while not self.stop_evt.is_set():
@@ -59,14 +63,18 @@ class Recorder(threading.Thread):
             self.pose.append(self.arm.pose())
             g = self.arm.finger(); self.grip.append([ (g[0]+g[1]) / 2 ])
             f1, f2 = pipe1.wait_for_frames(), pipe2.wait_for_frames()
-            cv2.imwrite(f"{SAVE_DIR}/color/v1_{idx}_{self.tag}.png", np.asarray(f1.get_color_frame().get_data()))
-            cv2.imwrite(f"{SAVE_DIR}/depth/v1_{idx}_{self.tag}.png", np.asarray(f1.get_depth_frame().get_data()))
-            cv2.imwrite(f"{SAVE_DIR}/color/v2_{idx}_{self.tag}.png", np.asarray(f2.get_color_frame().get_data()))
-            cv2.imwrite(f"{SAVE_DIR}/depth/v2_{idx}_{self.tag}.png", np.asarray(f2.get_depth_frame().get_data()))
+            cv2.imwrite(os.path.join(self.base, 'color', f"v1_{idx}.png"),
+                        np.asarray(f1.get_color_frame().get_data()))
+            cv2.imwrite(os.path.join(self.base, 'depth', f"v1_{idx}.png"),
+                        np.asarray(f1.get_depth_frame().get_data()))
+            cv2.imwrite(os.path.join(self.base, 'color', f"v2_{idx}.png"),
+                        np.asarray(f2.get_color_frame().get_data()))
+            cv2.imwrite(os.path.join(self.base, 'depth', f"v2_{idx}.png"),
+                        np.asarray(f2.get_depth_frame().get_data()))
             idx += 1; time.sleep(max(0, period-(time.time()-t0)))
     def stop(self):
         self.stop_evt.set(); self.join()
-        np.save(f"{SAVE_DIR}/pos_{self.tag}.npy",
+        np.save(os.path.join(self.base, 'pos.npy'),
                 np.hstack((np.array(self.pose), np.array(self.grip))))
         print(f"[rec] 保存完毕 {self.tag}")
 

--- a/data_collect/record_and_teleop_v2.py
+++ b/data_collect/record_and_teleop_v2.py
@@ -17,7 +17,7 @@ LIN_VEL   = 0.04        # m/s
 ANG_VEL   = 0.30        # rad/s
 PUB_HZ    = 100         # Kinova 官方要求 100 Hz:contentReference[oaicite:1]{index=1}
 REC_HZ    = 10
-SAVE_DIR  = 'data_record'; os.makedirs(f'{SAVE_DIR}/color',exist_ok=True); os.makedirs(f'{SAVE_DIR}/depth',exist_ok=True)
+SAVE_DIR  = 'data_record'; os.makedirs(SAVE_DIR, exist_ok=True)
 CAM1_SN, CAM2_SN = "243122075526", "243222073031"
 
 # ───────── 键盘读取 ─────────
@@ -49,6 +49,9 @@ class Recorder(threading.Thread):
         super().__init__(daemon=True)
         self.tag, self.arm, self.stop_evt = tag, arm, threading.Event()
         self.pose, self.grip = [], []
+        self.base = os.path.join(SAVE_DIR, self.tag)
+        os.makedirs(os.path.join(self.base,'color'), exist_ok=True)
+        os.makedirs(os.path.join(self.base,'depth'), exist_ok=True)
     def run(self):
         period = 1/REC_HZ; idx=0
         while not self.stop_evt.is_set():
@@ -57,14 +60,14 @@ class Recorder(threading.Thread):
             g=self.arm.finger(); self.grip.append([(g[0]+g[1])/2])
             # image
             f1,f2=pipe1.wait_for_frames(),pipe2.wait_for_frames()
-            cv2.imwrite(f"{SAVE_DIR}/color/v1_{idx}_{self.tag}.png",np.asarray(f1.get_color_frame().get_data()))
-            cv2.imwrite(f"{SAVE_DIR}/depth/v1_{idx}_{self.tag}.png",np.asarray(f1.get_depth_frame().get_data()))
-            cv2.imwrite(f"{SAVE_DIR}/color/v2_{idx}_{self.tag}.png",np.asarray(f2.get_color_frame().get_data()))
-            cv2.imwrite(f"{SAVE_DIR}/depth/v2_{idx}_{self.tag}.png",np.asarray(f2.get_depth_frame().get_data()))
+            cv2.imwrite(os.path.join(self.base,'color',f"v1_{idx}.png"),np.asarray(f1.get_color_frame().get_data()))
+            cv2.imwrite(os.path.join(self.base,'depth',f"v1_{idx}.png"),np.asarray(f1.get_depth_frame().get_data()))
+            cv2.imwrite(os.path.join(self.base,'color',f"v2_{idx}.png"),np.asarray(f2.get_color_frame().get_data()))
+            cv2.imwrite(os.path.join(self.base,'depth',f"v2_{idx}.png"),np.asarray(f2.get_depth_frame().get_data()))
             idx+=1; time.sleep(max(0,period-(time.time()-t0)))
     def stop(self):
         self.stop_evt.set(); self.join()
-        np.save(f"{SAVE_DIR}/pos_{self.tag}.npy",
+        np.save(os.path.join(self.base,'pos.npy'),
                 np.hstack((np.array(self.pose),np.array(self.grip))))
         print(f"[rec] 保存完毕 {self.tag}")
 

--- a/data_collect/replay_to_robot.py
+++ b/data_collect/replay_to_robot.py
@@ -3,30 +3,29 @@
 """
 replay_to_robot.py
 ──────────────────
-把指定批次的 pos_<tag>.npy 逐点回放到 Kinova 机械臂
+把指定批次目录下的 pos.npy 逐点回放到 Kinova 机械臂
 """
 
-import glob, sys, os, re, time, argparse, numpy as np
+import glob, sys, os, time, argparse, numpy as np
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from arm_kinova import Arm
 
 DATA_DIR = 'data_record'
-POS_RE   = re.compile(r'pos_(.+?)\.npy$')
 HZ       = 30           # 录制时 10 Hz
 DT       = 1 / HZ
 
 def pick_batch() -> str:
-    files = sorted(glob.glob(os.path.join(DATA_DIR, 'pos_*.npy')))
-    if not files: raise FileNotFoundError("No pos_*.npy found, record first.")
-    tags = [POS_RE.search(os.path.basename(f)).group(1) for f in files]
+    files = sorted(glob.glob(os.path.join(DATA_DIR, '*/pos.npy')))
+    if not files: raise FileNotFoundError("No */pos.npy found, record first.")
+    tags = [os.path.basename(os.path.dirname(f)) for f in files]
     print("Available batches:")
     for i, t in enumerate(tags): print(f"[{i}] {t}")
     idx = int(input(f"Select batch 0-{len(tags)-1}: "))
     return tags[idx]
 
 def main(tag: str, dry_run: bool):
-    path = os.path.join(DATA_DIR, f'pos_{tag}.npy')
+    path = os.path.join(DATA_DIR, tag, 'pos.npy')
     traj = np.load(path)[:, :6]        # X Y Z R P Y
     print(f"Loaded {traj.shape[0]} waypoints from {path}")
 

--- a/data_collect/replay_trajectory_and_video.py
+++ b/data_collect/replay_trajectory_and_video.py
@@ -16,33 +16,34 @@ CMAP       = cv2.COLORMAP_JET
 AXIS_LEN   = 0.03      # 三轴箭头长度 (m)
 
 # ----- 文件名正则 -----
-POS_RE = re.compile(r'pos_(.+?)\.npy$')
-IMG_RE = re.compile(r'v1_(\d+?)_(.+?)\.png$')    # idx, tag
+IMG_RE = re.compile(r'v1_(\d+)\.png$')    # idx
 
 # ----- 扫描批次 -----
-pos_files = sorted(glob.glob(os.path.join(DATA_DIR, 'pos_*.npy')))
-if not pos_files: raise FileNotFoundError("no pos_*.npy ; run recorder first")
+pos_files = sorted(glob.glob(os.path.join(DATA_DIR, '*/pos.npy')))
+if not pos_files: raise FileNotFoundError("no */pos.npy ; run recorder first")
 
-tags = [POS_RE.search(os.path.basename(f)).group(1) for f in pos_files]
+tags = [os.path.basename(os.path.dirname(f)) for f in pos_files]
 for i,t in enumerate(tags): print(f"[{i}] {t}")
 tag = tags[int(input(f"Select batch 0-{len(tags)-1}: "))]
 
 # ----- 载入位姿 (X Y Z R P Y) -----
-pose6 = np.load(os.path.join(DATA_DIR, f'pos_{tag}.npy'))[:, :6]
+pose6 = np.load(os.path.join(DATA_DIR, tag, 'pos.npy'))[:, :6]
 xyz = pose6[:, :3]; rpy = pose6[:, 3:]
 n_frames = xyz.shape[0]
 
 # ----- 图片路径 -----
 pattern = IMG_RE
-color_dict, depth_dict = {}, {}
-for p in glob.glob(os.path.join(DATA_DIR, f'color/v1_*_{tag}.png')):
-    m=pattern.search(os.path.basename(p)); idx=int(m.group(1)); typ='color'
-    color_dict[idx]=p
-    # 对应深度
-    dp = p.replace('/color/','/depth/').replace('v1_','v1_')
-    if os.path.exists(dp): depth_dict[idx]=dp
-color_paths =[color_dict[i] for i in sorted(color_dict)]
-depth_paths =[depth_dict[i] for i in sorted(depth_dict)] if SHOW_DEPTH else None
+color_paths = sorted(
+    glob.glob(os.path.join(DATA_DIR, tag, 'color', 'v1_*.png')),
+    key=lambda p: int(pattern.search(os.path.basename(p)).group(1))
+)
+if SHOW_DEPTH:
+    depth_paths = [
+        p.replace(os.sep+'color'+os.sep, os.sep+'depth'+os.sep)
+        for p in color_paths
+    ]
+else:
+    depth_paths = None
 
 # ---- 读取图像 ----
 def read_color(i): return cv2.cvtColor(cv2.imread(color_paths[i]), cv2.COLOR_BGR2RGB)


### PR DESCRIPTION
## Summary
- Store each teleop recording in its own subdirectory with separate color and depth folders
- Update replay and plotting utilities to load data from the new per-tag folder structure
- Align alternate recorder scripts with the new directory layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy keyboard -q` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6895609c5bd08332afffff15ac487d32