### PR TITLE
Record and replay gripper state

### DIFF
--- a/data_collect/replay_to_robot.py
+++ b/data_collect/replay_to_robot.py
@@ -3,7 +3,8 @@
 """
 replay_to_robot.py
 ──────────────────
-把指定批次的 pos_<tag>.npy 逐点回放到 Kinova 机械臂
+把指定批次的 pos_<tag>.npy 逐点回放到 Kinova 机械臂。
+同时复现录制时的夹爪开合。
 """
 
 import glob, sys, os, re, time, argparse, numpy as np
@@ -13,7 +14,7 @@ from arm_kinova import Arm
 
 DATA_DIR = 'data_record'
 POS_RE   = re.compile(r'pos_(.+?)\.npy$')
-HZ       = 30           # 录制时 10 Hz
+HZ       = 10           # 回放频率 (与数据采集一致)
 DT       = 1 / HZ
 
 def pick_batch() -> str:
@@ -27,14 +28,22 @@ def pick_batch() -> str:
 
 def main(tag: str, dry_run: bool):
     path = os.path.join(DATA_DIR, f'pos_{tag}.npy')
-    traj = np.load(path)[:, :6]        # X Y Z R P Y
-    print(f"Loaded {traj.shape[0]} waypoints from {path}")
+    data = np.load(path)
+    pose = data[:, :6]                 # X Y Z R P Y
+    grip = data[:, 6] if data.shape[1] > 6 else None
+    if grip is None:
+        print(f"Loaded {pose.shape[0]} waypoints from {path} (no gripper data)")
+    else:
+        print(f"Loaded {pose.shape[0]} waypoints from {path} with gripper track")
 
     if dry_run:
         print("Dry-run only → no motion commands will be sent.")
-        for i, p in enumerate(traj):
-            print(f"{i:4d}  x={p[0]:.3f}  y={p[1]:.3f}  z={p[2]:.3f}  "
-                  f"r={np.degrees(p[3]):.1f}°  p={np.degrees(p[4]):.1f}°  y={np.degrees(p[5]):.1f}°")
+        for i, p in enumerate(pose):
+            line = (f"{i:4d}  x={p[0]:.3f}  y={p[1]:.3f}  z={p[2]:.3f}  "
+                    f"r={np.degrees(p[3]):.1f}°  p={np.degrees(p[4]):.1f}°  y={np.degrees(p[5]):.1f}°")
+            if grip is not None:
+                line += f"  g={grip[i]:.1f}"
+            print(line)
         return
 
     arm = Arm.load()                   # 默认 cfg/cfg_arm_left.yaml
@@ -42,13 +51,20 @@ def main(tag: str, dry_run: bool):
 
     print("Start replay…   (Ctrl+C to abort)")
     try:
-        for i, p in enumerate(traj):
+        last_grip = None
+        for i, p in enumerate(pose):
             t0 = time.time()
             arm.move_abs(p, blocking=False)    # 非阻塞发送，保持节奏
+            if grip is not None:
+                g_val = grip[i]
+                if not np.isnan(g_val) and (last_grip is None or abs(g_val - last_grip) > 1e-3):
+                    arm.set_gripper(float(g_val))
+                    last_grip = g_val
             dt = time.time() - t0
-            if dt < DT: time.sleep(DT - dt)
+            if dt < DT:
+                time.sleep(DT - dt)
             if i % 50 == 0:
-                print(f" sent {i+1}/{len(traj)}")
+                print(f" sent {i+1}/{len(pose)}")
         print("✓ Replay finished.")
     except KeyboardInterrupt:
         print("\nUser aborted.")


### PR DESCRIPTION
## Summary
- capture gripper position in ROS data collector
- replay logged gripper movement alongside arm poses
- handle optional gripper track and avoid redundant gripper commands during replay

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy', ModuleNotFoundError: No module named 'keyboard')*


------
https://chatgpt.com/codex/tasks/task_e_6895b2efc1a48332891c7354047ce378