### PR TITLE
Ensure gripper actions complete to avoid lost commands

### DIFF
--- a/arm_kinova.py
+++ b/arm_kinova.py
@@ -184,23 +184,38 @@ class Arm:
         self._vel_pub.publish(msg)
 
     # 夹爪
-    def set_gripper(self,val):
+    def set_gripper(self, val, wait=True, timeout=5.0):
+        """Send a finger position goal to the gripper.
+
+        Args:
+            val (float): Target finger position.
+            wait (bool): If True, block until the action is reported finished.
+            timeout (float): Maximum time to wait for the action result (seconds).
+        """
         import kinova_msgs.msg as km
         goal = km.SetFingersPositionGoal()
         goal.fingers.finger1 = goal.fingers.finger2 = val
         goal.fingers.finger3 = 0.0
         self._grip_cli.send_goal(goal)
+        if wait:
+            self._grip_cli.wait_for_result(rospy.Duration(timeout))
 
-    def control_gripper(self, open_value):
-        self.set_gripper(open_value)
+    def control_gripper(self, open_value, wait=True, timeout=5.0):
+        """Convenience wrapper to control the gripper opening.
 
-    def open_gripper(self):
+        This function now waits for the action result by default to avoid
+        command loss when a new goal is sent before the previous one
+        completes.
+        """
+        self.set_gripper(open_value, wait=wait, timeout=timeout)
+
+    def open_gripper(self, wait=True, timeout=5.0):
         """Open the gripper to its configured open position."""
-        self.set_gripper(self.g_open)
+        self.set_gripper(self.g_open, wait=wait, timeout=timeout)
 
-    def close_gripper(self):
+    def close_gripper(self, wait=True, timeout=5.0):
         """Close the gripper to its configured closed position."""
-        self.set_gripper(self.g_close)
+        self.set_gripper(self.g_close, wait=wait, timeout=timeout)
 
     def target2cam_xyzrpy_to_target2base_xyzrpy(self, xyzrpy_cam):
         """

--- a/main_open_door.py
+++ b/main_open_door.py
@@ -268,7 +268,8 @@ def main():
 
         # a. Open gripper and move to grasp position
         print("Step 1: Opening gripper...")
-        arm.control_gripper(open_value=0)  # Open wide
+        # Wait for the gripper to fully open before proceeding
+        arm.control_gripper(open_value=0, wait=True)  # Open wide
         time.sleep(1)
 
         print(f"Step 2: Moving to handle at {np.round(pos_grasp_base[:3], 4)}...")
@@ -277,7 +278,8 @@ def main():
 
         # b. Close gripper to grasp handle
         print("Step 3: Grasping handle...")
-        arm.control_gripper(open_value=6000)  # Close to grasp
+        # Wait for the close action to complete to avoid command loss
+        arm.control_gripper(open_value=6000, wait=True)  # Close to grasp
         time.sleep(1.5)  # Wait for grasp to be firm
 
         # Optional: Check if grasp was successful
@@ -302,7 +304,7 @@ def main():
         # --- 6. Cleanup and Shutdown ---
         print("\n--- Mission Finished. Returning to home position. ---")
         # Optional: Add a 'home_position' and move the arm back
-        arm.control_gripper(open_value=0)
+        arm.control_gripper(open_value=0, wait=True)
         arm.move_p(HOME_POSITION)
         # For now, just release the gripper
         time.sleep(1)

--- a/primitives/approach.py
+++ b/primitives/approach.py
@@ -23,7 +23,8 @@ def approach_handle(arm: Any, target_pose: Sequence[float]) -> None:
         return
 
     if hasattr(arm, "control_gripper"):
-        arm.control_gripper(open_value=0)
+        # Ensure gripper command completes before proceeding
+        arm.control_gripper(open_value=0, wait=True)
 
     if hasattr(arm, "move_p"):
         arm.move_p(list(target_pose))


### PR DESCRIPTION
## Summary
- Make gripper control wait for action results to prevent command loss
- Use blocking gripper commands in door-opening routine and approach primitive

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b3093edbc8833282df35b2308c22e7