### PR TITLE
feat: reset arm to home position

### DIFF
--- a/primitives/retreat.py
+++ b/primitives/retreat.py
@@ -1,25 +1,34 @@
-"""Primitives for retreating either the gripper or the base."""
+"""Primitives for retreating the robot."""
 
-from typing import Any
+from typing import Any, Sequence
 
 
-def retreat_gripper(arm: Any, distance: float = 0.2) -> None:
-    """Move the gripper ``distance`` meters in the +Y direction.
+# Default "home" pose for resetting the arm.
+HOME_POSITION = [
+    0.21248655021190643,
+    -0.2564840614795685,
+    0.5075023174285889,
+    1.512,
+    -0.184,
+    -1.422,
+]
+
+
+def retreat_gripper(arm: Any, home_position: Sequence[float] = HOME_POSITION) -> None:
+    """Return the arm to the ``home_position``.
 
     Parameters
     ----------
     arm:
-        Arm-like object providing ``pose`` and ``move_p`` methods.
-    distance:
-        Positive offset along the Y axis in meters.
+        Arm-like object providing a ``move_p`` method.
+    home_position:
+        Target pose representing the arm's "home" configuration.
     """
     if arm is None:
         return
 
-    if hasattr(arm, "pose") and hasattr(arm, "move_p"):
-        current = list(arm.pose())
-        current[1] += abs(distance)
-        arm.move_p(current)
+    if hasattr(arm, "move_p"):
+        arm.move_p(list(home_position))
 
 
 def retreat_base(base: Any, time_s: float = 2.0, linear_velocity: float = 0.2) -> None:

--- a/tasks/door_open_sm.py
+++ b/tasks/door_open_sm.py
@@ -28,7 +28,6 @@ class DoorOpenStateMachine:
         max_attempts: int = 3,
         base_backoff_time: float = 2.0,
         base_backoff_velocity: float = 0.2,
-        retry_backoff_distance: float = 0.2,
         approach_force_threshold: float = 10.0,
     ):
         self.arm = arm
@@ -36,7 +35,6 @@ class DoorOpenStateMachine:
         self.max_attempts = max_attempts
         self.base_backoff_time = base_backoff_time
         self.base_backoff_velocity = base_backoff_velocity
-        self.retry_backoff_distance = retry_backoff_distance
         self.approach_force_threshold = approach_force_threshold
         self.state = self.APPROACH
         self.joint3_history: List[float] = []
@@ -66,6 +64,8 @@ class DoorOpenStateMachine:
 
         while attempts < self.max_attempts:
             if self.state == self.APPROACH:
+                # Reset the arm before each detection attempt
+                retreat_gripper(self.arm)
                 poses = pose_fn()
                 if poses is None:
                     return self.ERROR
@@ -88,7 +88,7 @@ class DoorOpenStateMachine:
                     self.arm, self.joint3_history, pull_pose, log_path
                 )
                 if error:
-                    retreat_gripper(self.arm, self.retry_backoff_distance)
+                    retreat_gripper(self.arm)
                     attempts += 1
                     self.joint3_history.clear()
                     self.state = self.APPROACH

--- a/tasks/door_open_task.py
+++ b/tasks/door_open_task.py
@@ -96,7 +96,6 @@ def open_door(
         max_attempts=cfg.state_machine.max_attempts,
         base_backoff_time=cfg.base_backoff.time,
         base_backoff_velocity=cfg.base_backoff.linear_velocity,
-        retry_backoff_distance=cfg.retry_backoff.distance,
         approach_force_threshold=getattr(cfg, "approach_force_threshold", 10.0),
     )
     result = sm.run(detect_and_plan)


### PR DESCRIPTION
## Summary
- reset retreat_gripper primitive to move arm back to predefined home pose
- reset arm before each handle detection and after failed pulls in the door opening state machine
- simplify door_open_task to reflect new primitive usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c515aab39883329caa8fb174b6c4e4