### PR TITLE
Enhance door-opening sequence with arm extension

### DIFF
--- a/primitives/__init__.py
+++ b/primitives/__init__.py
@@ -5,6 +5,7 @@ from .grasp import grasp_handle
 from .pull import pull_handle_and_check, evaluate_joint3_effort
 from .retreat import retreat_gripper, retreat_base
 from .push import push_door
+from .extend import extend_forward_left
 
 __all__ = [
     "approach_handle",
@@ -15,4 +16,5 @@ __all__ = [
     "retreat_gripper",
     "retreat_base",
     "push_door",
+    "extend_forward_left",
 ]

--- a/primitives/extend.py
+++ b/primitives/extend.py
@@ -1,0 +1,30 @@
+"""Primitive to extend the arm forward-left after releasing the door handle."""
+
+from typing import Any, Sequence
+
+
+def extend_forward_left(
+    arm: Any, current_pose: Sequence[float], forward: float = 0.1, left: float = 0.1
+) -> None:
+    """Extend the arm from ``current_pose`` forward and left.
+
+    Parameters
+    ----------
+    arm:
+        Arm-like object providing ``move_p``.
+    current_pose:
+        Reference pose [x, y, z, roll, pitch, yaw].
+    forward:
+        Distance to move along the positive x-axis.
+    left:
+        Distance to move along the positive y-axis.
+    """
+    if arm is None or current_pose is None:
+        return
+
+    target = list(current_pose)
+    target[0] += forward
+    target[1] += left
+
+    if hasattr(arm, "move_p"):
+        arm.move_p(target)

--- a/tasks/door_open_sm.py
+++ b/tasks/door_open_sm.py
@@ -9,6 +9,7 @@ from primitives import (
     retreat_base,
     pull_handle_and_check,
     push_door,
+    extend_forward_left,
 )
 
 
@@ -101,6 +102,10 @@ class DoorOpenStateMachine:
             elif self.state == self.PUSH:
                 if push_pose is not None:
                     push_door(self.arm, push_pose)
+                    if hasattr(self.arm, "open_gripper"):
+                        self.arm.open_gripper()
+                    extend_forward_left(self.arm, push_pose)
+                    retreat_gripper(self.arm)
                 self.state = self.MOVE_BASE
 
             elif self.state == self.MOVE_BASE:


### PR DESCRIPTION
## Summary
- add primitive to extend arm forward-left
- open gripper, extend, and return home after push in door state machine

## Testing
- `pytest` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c54d3b9ee483329d9b2e02f2d3e453