### PR TITLE
feat: add odometry closed-loop control for base

### DIFF
--- a/primitives/__init__.py
+++ b/primitives/__init__.py
@@ -3,7 +3,7 @@
 from .approach import approach_handle, approach_handle_and_check_force
 from .grasp import grasp_handle
 from .pull import pull_handle_and_check, evaluate_joint3_effort
-from .retreat import retreat_gripper, retreat_base
+from .retreat import retreat_gripper, retreat_base, retreat_home
 from .push import push_door
 from .extend import extend_forward_left
 
@@ -17,4 +17,5 @@ __all__ = [
     "retreat_base",
     "push_door",
     "extend_forward_left",
+    "retreat_home",
 ]

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -3,10 +3,12 @@
 from .door_open_sm import DoorOpenStateMachine
 from .door_open_task import open_door
 from .handle_detection import get_handle_coords_manual, get_handle_coords_model
+from .door2button import auto_playback
 
 __all__ = [
     "DoorOpenStateMachine",
     "open_door",
     "get_handle_coords_manual",
     "get_handle_coords_model",
+    "auto_playback",
 ]

--- a/tasks/handle_detection.py
+++ b/tasks/handle_detection.py
@@ -4,7 +4,7 @@ import os
 import time
 import tempfile
 from datetime import datetime
-from typing import Tuple
+from typing import Tuple, Optional
 
 import cv2
 import requests
@@ -72,7 +72,7 @@ DEFAULT_HANDLE_DET_HOST = os.environ.get("HANDLE_DETECTION_HOST", "http://127.0.
 
 
 def get_handle_coords_model(
-    cam: Camera, host: str | None = None, save_dir: str = "handle_images"
+    cam: Camera, host: Optional[str] = None, save_dir: str = "handle_images"
 ) -> Tuple[float, float, float]:
     """Detect handle with a vision model and return coordinates in camera frame.
 


### PR DESCRIPTION
## Summary
- add PID-based closed-loop helpers for linear, strafing, and rotational moves that rely on odometry feedback
- expand the navigation interface with waypoint traversal, cancellation, and status helpers
- refresh module documentation and the example script to highlight the new motion primitives

## Testing
- pytest *(fails: missing numpy and keyboard dependencies in test environment)*
- python -m compileall dog_gs.py

------
https://chatgpt.com/codex/tasks/task_e_68caaee1a8688332a965e6d5b96a9150