### PR TITLE
Add ROS2 robot dog lie-down command support

### DIFF
--- a/dog_gs.py
+++ b/dog_gs.py
@@ -38,42 +38,44 @@ import actionlib
 from move_base_msgs.msg import MoveBaseAction, MoveBaseGoal
 
 
-def _call_robot_command_service(
+def _make_robot_command_request():
+    """Create an empty RobotCommand request instance."""
+
+    if RobotCommandSrv is None:
+        raise RuntimeError(
+            "RobotCommand service support requires the message definitions to be installed."
+        )
+
+    request_cls = getattr(RobotCommandSrv, "Request", None)
+    if request_cls is None:
+        request_cls = getattr(RobotCommandSrv, "_request_class", None)
+
+    if request_cls is None:  # pragma: no cover - depends on runtime bindings
+        raise RuntimeError("RobotCommand request type is unavailable.")
+
+    return request_cls()
+
+
+def _set_robot_command_name(request, command_name):
+    """Populate the command field on a RobotCommand request."""
+
+    if hasattr(request, "comamnd_name"):
+        setattr(request, "comamnd_name", command_name)
+    elif hasattr(request, "command_name"):
+        setattr(request, "command_name", command_name)
+    else:  # pragma: no cover - defensive for unexpected interface
+        raise AttributeError(
+            "RobotCommand request does not define 'comamnd_name' or 'command_name'."
+        )
+
+
+def _call_robot_command_service_ros2(
     command_name,
     *,
     service_name="/nav/robot_command",
     timeout_sec=5.0,
 ):
-    """Send a ``RobotCommand`` request via ROS 2.
-
-    Parameters
-    ----------
-    command_name:
-        Name of the command to send to the robot.  For the Unitree-based
-        quadruped the ``"StandUpDown"`` command toggles between standing and
-        lying postures.
-    service_name:
-        Fully qualified service name.  Defaults to ``"/nav/robot_command"`` to
-        match the bridge configuration used on the robot platform.
-    timeout_sec:
-        Maximum amount of time to wait for the service to become available and
-        to return a response.
-
-    Returns
-    -------
-    ysc_robot_msgs.srv.RobotCommand.Response
-        The ROS 2 service response object.
-
-    Raises
-    ------
-    RuntimeError
-        If ROS 2 support is not available or the service fails.
-    TimeoutError
-        If the service call exceeds ``timeout_sec`` seconds.
-    AttributeError
-        If the ``RobotCommand`` request does not expose a recognised command
-        field name.
-    """
+    """Send a ``RobotCommand`` request via ROS 2."""
 
     if rclpy is None or RobotCommandSrv is None:
         raise RuntimeError(
@@ -81,8 +83,6 @@ def _call_robot_command_service(
             "the 'ysc_robot_msgs' interfaces to be installed."
         )
 
-    # ``is_initialized`` was introduced in ROS 2 Foxy; fall back to checking
-    # ``rclpy.ok()`` on older distributions where needed.
     needs_shutdown = False
     is_init = False
     if rclpy_is_initialized is not None:
@@ -106,15 +106,8 @@ def _call_robot_command_service(
                 f"Service '{service_name}' unavailable after {timeout_sec} seconds."
             )
 
-        request = RobotCommandSrv.Request()
-        if hasattr(request, "comamnd_name"):
-            setattr(request, "comamnd_name", command_name)
-        elif hasattr(request, "command_name"):
-            setattr(request, "command_name", command_name)
-        else:
-            raise AttributeError(
-                "RobotCommand request does not define 'comamnd_name' or 'command_name'."
-            )
+        request = _make_robot_command_request()
+        _set_robot_command_name(request, command_name)
 
         future = client.call_async(request)
 
@@ -143,6 +136,91 @@ def _call_robot_command_service(
         node.destroy_node()
         if needs_shutdown:
             rclpy.shutdown()
+
+
+def _call_robot_command_service_ros1(
+    command_name,
+    *,
+    service_name="/nav/robot_command",
+    timeout_sec=5.0,
+):
+    """Send a ``RobotCommand`` request via ROS 1."""
+
+    if RobotCommandSrv is None:
+        raise RuntimeError(
+            "RobotCommand service support requires the message definitions to be installed."
+        )
+
+    try:
+        rospy.wait_for_service(service_name, timeout=timeout_sec)
+    except rospy.ROSException as exc:
+        raise TimeoutError(
+            f"Service '{service_name}' unavailable after {timeout_sec} seconds."
+        ) from exc
+
+    client = rospy.ServiceProxy(service_name, RobotCommandSrv)
+    request = _make_robot_command_request()
+    _set_robot_command_name(request, command_name)
+
+    try:
+        return client(request)
+    except rospy.ServiceException as exc:  # pragma: no cover - depends on ROS runtime
+        raise RuntimeError(f"Robot command service failed via ROS 1: {exc}") from exc
+
+
+def _call_robot_command_service(
+    command_name,
+    *,
+    service_name="/nav/robot_command",
+    timeout_sec=5.0,
+    transport="auto",
+):
+    """Send a ``RobotCommand`` request using ROS 1, ROS 2 or both."""
+
+    if transport not in {"auto", "ros1", "ros2"}:
+        raise ValueError("transport must be 'auto', 'ros1', or 'ros2'.")
+
+    transports_to_try = []
+    if transport == "ros2":
+        transports_to_try = ["ros2"]
+    elif transport == "ros1":
+        transports_to_try = ["ros1"]
+    else:  # auto
+        if rclpy is not None:
+            transports_to_try.append("ros2")
+        transports_to_try.append("ros1")
+
+    last_exc = None
+    for idx, mode in enumerate(transports_to_try):
+        try:
+            if mode == "ros2":
+                return _call_robot_command_service_ros2(
+                    command_name,
+                    service_name=service_name,
+                    timeout_sec=timeout_sec,
+                )
+            return _call_robot_command_service_ros1(
+                command_name,
+                service_name=service_name,
+                timeout_sec=timeout_sec,
+            )
+        except Exception as exc:  # pragma: no cover - runtime dependent
+            last_exc = exc
+            if idx < len(transports_to_try) - 1:
+                next_mode = transports_to_try[idx + 1]
+                rospy.logwarn(
+                    "RobotCommand via ROS %s failed (%s); trying ROS %s instead.",
+                    mode.upper(),
+                    exc,
+                    next_mode.upper(),
+                )
+            else:
+                raise
+
+    if last_exc is not None:  # pragma: no cover - defensive
+        raise last_exc
+
+    raise RuntimeError("No transport available for RobotCommand requests.")
 
 
 class RosBase(object):
@@ -448,8 +526,9 @@ class RosBase(object):
         *,
         service_name="/nav/robot_command",
         timeout_sec=5.0,
+        transport="auto",
     ):
-        """Send a low-level RobotCommand service request via ROS 2.
+        """Send a low-level RobotCommand service request via ROS 1/ROS 2.
 
         Parameters
         ----------
@@ -461,6 +540,10 @@ class RosBase(object):
             in the ROS1/ROS2 bridge configuration.
         timeout_sec:
             Maximum amount of time to wait for the service to respond.
+        transport:
+            Communication transport to use.  ``"auto"`` (default) first attempts
+            ROS 2 if available and falls back to ROS 1, ``"ros1"`` forces the
+            ROS 1 service proxy, and ``"ros2"`` forces the ROS 2 client.
 
         Returns
         -------
@@ -472,7 +555,7 @@ class RosBase(object):
         TimeoutError
             If the service call exceeds ``timeout_sec`` seconds.
         RuntimeError
-            If the call fails or ROS 2 support is unavailable.
+            If the call fails or the requested transport is unavailable.
         """
 
         try:
@@ -480,6 +563,7 @@ class RosBase(object):
                 command_name,
                 service_name=service_name,
                 timeout_sec=timeout_sec,
+                transport=transport,
             )
         except TimeoutError as exc:
             rospy.logerr(
@@ -495,12 +579,14 @@ class RosBase(object):
         *,
         service_name="/nav/robot_command",
         timeout_sec=5.0,
+        transport="auto",
     ):
         """Request the quadruped to assume a lying posture.
 
         This helper wraps the ``StandUpDown`` command exposed via the
-        ``/nav/robot_command`` ROS 2 service, allowing callers to trigger the
-        posture change directly from Python.
+        ``/nav/robot_command`` service, allowing callers to trigger the posture
+        change directly from Python whether the service is accessed through
+        ROS 2 or a ROS1/ROS2 bridge.
 
         Parameters
         ----------
@@ -508,6 +594,8 @@ class RosBase(object):
             Target service name.  Defaults to ``"/nav/robot_command"``.
         timeout_sec:
             Maximum amount of time to wait for the service to respond.
+        transport:
+            Transport selector forwarded to :meth:`send_robot_command`.
 
         Returns
         -------
@@ -519,6 +607,7 @@ class RosBase(object):
             "StandUpDown",
             service_name=service_name,
             timeout_sec=timeout_sec,
+            transport=transport,
         )
 
         # Try to provide informative logging regardless of the specific

--- a/dog_gs.py
+++ b/dog_gs.py
@@ -15,6 +15,18 @@ import time
 import os
 import threading
 
+try:  # Optional ROS 2 imports used for posture control commands
+    import rclpy
+    from rclpy.utilities import is_initialized as rclpy_is_initialized
+except ImportError:  # pragma: no cover - ROS 2 not installed in some environments
+    rclpy = None
+    rclpy_is_initialized = None
+
+try:  # RobotCommand service definition lives in the ROS 2 workspace
+    from ysc_robot_msgs.srv import RobotCommand as RobotCommandSrv
+except ImportError:  # pragma: no cover - service definition unavailable during tests
+    RobotCommandSrv = None
+
 # Conditional import for keyboard control
 if os.name == "nt":
     import msvcrt
@@ -24,6 +36,113 @@ else:
 # Imports for ROS Navigation Stack
 import actionlib
 from move_base_msgs.msg import MoveBaseAction, MoveBaseGoal
+
+
+def _call_robot_command_service(
+    command_name,
+    *,
+    service_name="/nav/robot_command",
+    timeout_sec=5.0,
+):
+    """Send a ``RobotCommand`` request via ROS 2.
+
+    Parameters
+    ----------
+    command_name:
+        Name of the command to send to the robot.  For the Unitree-based
+        quadruped the ``"StandUpDown"`` command toggles between standing and
+        lying postures.
+    service_name:
+        Fully qualified service name.  Defaults to ``"/nav/robot_command"`` to
+        match the bridge configuration used on the robot platform.
+    timeout_sec:
+        Maximum amount of time to wait for the service to become available and
+        to return a response.
+
+    Returns
+    -------
+    ysc_robot_msgs.srv.RobotCommand.Response
+        The ROS 2 service response object.
+
+    Raises
+    ------
+    RuntimeError
+        If ROS 2 support is not available or the service fails.
+    TimeoutError
+        If the service call exceeds ``timeout_sec`` seconds.
+    AttributeError
+        If the ``RobotCommand`` request does not expose a recognised command
+        field name.
+    """
+
+    if rclpy is None or RobotCommandSrv is None:
+        raise RuntimeError(
+            "RobotCommand service support requires the ROS 2 Python packages and "
+            "the 'ysc_robot_msgs' interfaces to be installed."
+        )
+
+    # ``is_initialized`` was introduced in ROS 2 Foxy; fall back to checking
+    # ``rclpy.ok()`` on older distributions where needed.
+    needs_shutdown = False
+    is_init = False
+    if rclpy_is_initialized is not None:
+        is_init = rclpy_is_initialized()
+    else:  # pragma: no cover - depends on ROS 2 version at runtime
+        try:
+            is_init = rclpy.ok()
+        except Exception:
+            is_init = False
+
+    if not is_init:
+        rclpy.init(args=None)
+        needs_shutdown = True
+
+    node = rclpy.create_node("dog_gs_robot_command_client")
+
+    try:
+        client = node.create_client(RobotCommandSrv, service_name)
+        if not client.wait_for_service(timeout_sec=timeout_sec):
+            raise TimeoutError(
+                f"Service '{service_name}' unavailable after {timeout_sec} seconds."
+            )
+
+        request = RobotCommandSrv.Request()
+        if hasattr(request, "comamnd_name"):
+            setattr(request, "comamnd_name", command_name)
+        elif hasattr(request, "command_name"):
+            setattr(request, "command_name", command_name)
+        else:
+            raise AttributeError(
+                "RobotCommand request does not define 'comamnd_name' or 'command_name'."
+            )
+
+        future = client.call_async(request)
+
+        end_time = time.monotonic() + timeout_sec if timeout_sec is not None else None
+        while rclpy.ok() and not future.done():
+            spin_timeout = 0.1
+            if end_time is not None:
+                remaining = end_time - time.monotonic()
+                if remaining <= 0:
+                    future.cancel()
+                    raise TimeoutError(
+                        f"Robot command '{command_name}' timed out after {timeout_sec} seconds."
+                    )
+                spin_timeout = min(spin_timeout, max(0.0, remaining))
+            rclpy.spin_once(node, timeout_sec=spin_timeout)
+
+        if future.cancelled():  # pragma: no cover - defensive
+            raise RuntimeError("Robot command service call was cancelled.")
+
+        exception = future.exception()
+        if exception is not None:
+            raise RuntimeError(f"Robot command service failed: {exception}")
+
+        return future.result()
+    finally:
+        node.destroy_node()
+        if needs_shutdown:
+            rclpy.shutdown()
 
 
 class RosBase(object):
@@ -319,6 +438,101 @@ class RosBase(object):
         self.move_stop()
         self.odom_subscriber.unregister()
         rospy.signal_shutdown("Shutdown requested.")
+
+    # ------------------------------------------------------------------ #
+    # Robot dog posture control
+    # ------------------------------------------------------------------ #
+    def send_robot_command(
+        self,
+        command_name,
+        *,
+        service_name="/nav/robot_command",
+        timeout_sec=5.0,
+    ):
+        """Send a low-level RobotCommand service request via ROS 2.
+
+        Parameters
+        ----------
+        command_name:
+            Name of the command to send to the quadruped.  ``"StandUpDown"``
+            toggles between standing and lying postures on the Unitree robot.
+        service_name:
+            Target service name.  Defaults to ``"/nav/robot_command"`` as used
+            in the ROS1/ROS2 bridge configuration.
+        timeout_sec:
+            Maximum amount of time to wait for the service to respond.
+
+        Returns
+        -------
+        ysc_robot_msgs.srv.RobotCommand.Response
+            The response returned by the service.
+
+        Raises
+        ------
+        TimeoutError
+            If the service call exceeds ``timeout_sec`` seconds.
+        RuntimeError
+            If the call fails or ROS 2 support is unavailable.
+        """
+
+        try:
+            return _call_robot_command_service(
+                command_name,
+                service_name=service_name,
+                timeout_sec=timeout_sec,
+            )
+        except TimeoutError as exc:
+            rospy.logerr(
+                f"Timed out while waiting for robot command '{command_name}': {exc}"
+            )
+            raise
+        except Exception as exc:
+            rospy.logerr(f"Failed to call robot command '{command_name}': {exc}")
+            raise
+
+    def lie_down(
+        self,
+        *,
+        service_name="/nav/robot_command",
+        timeout_sec=5.0,
+    ):
+        """Request the quadruped to assume a lying posture.
+
+        This helper wraps the ``StandUpDown`` command exposed via the
+        ``/nav/robot_command`` ROS 2 service, allowing callers to trigger the
+        posture change directly from Python.
+
+        Parameters
+        ----------
+        service_name:
+            Target service name.  Defaults to ``"/nav/robot_command"``.
+        timeout_sec:
+            Maximum amount of time to wait for the service to respond.
+
+        Returns
+        -------
+        ysc_robot_msgs.srv.RobotCommand.Response
+            The response returned by the service call.
+        """
+
+        response = self.send_robot_command(
+            "StandUpDown",
+            service_name=service_name,
+            timeout_sec=timeout_sec,
+        )
+
+        # Try to provide informative logging regardless of the specific
+        # response schema implemented by the firmware.
+        if response is None:
+            rospy.loginfo("StandUpDown command sent; no response payload returned.")
+        elif hasattr(response, "success"):
+            rospy.loginfo(
+                "StandUpDown command acknowledged with success=%s.", response.success
+            )
+        else:
+            rospy.loginfo("StandUpDown command response: %s", response)
+
+        return response
 
 
 if __name__ == "__main__":

--- a/tasks/target_detection.py
+++ b/tasks/target_detection.py
@@ -112,67 +112,95 @@ def get_target_coords_model(
     """Detect a target with a remote vision model and return 3D coordinates."""
     print(f"\n--- Starting Model-Based {target_name.title()} Detection ---")
 
-    rgb_img, depth_img = cam.capture_rgbd()
-    if rgb_img is None or depth_img is None:
-        print("[ERROR] Failed to capture RGBD frame.")
-        return None, None, None
-
-    os.makedirs(save_dir, exist_ok=True)
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    raw_path = os.path.join(save_dir, f"{timestamp}_rgb.jpg")
-    cv2.imwrite(raw_path, rgb_img)
-
     resolved_host = _resolve_host(host, host_env_var, default_host)
     endpoint = endpoint.strip("/ ")
     url = f"{resolved_host.rstrip('/')}/{endpoint}"
 
-    with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
-        tmp_path = tmp.name
-    try:
-        cv2.imwrite(tmp_path, rgb_img)
-        with open(tmp_path, "rb") as f:
-            response = requests.post(url, files={"file": f}, timeout=request_timeout)
-        response.raise_for_status()
-        result = response.json()
-        x, y = result.get("x"), result.get("y")
-    except Exception as ex:  # pragma: no cover
-        print(f"[ERROR] Model inference failed: {ex}")
-        return None, None, None
-    finally:
-        if os.path.exists(tmp_path):
-            os.remove(tmp_path)
+    os.makedirs(save_dir, exist_ok=True)
 
-    if x is None or y is None:
-        print("[ERROR] Model failed to detect the target.")
-        return None, None, None
+    def _cleanup_attempt_files(*paths: str) -> None:
+        for path in paths:
+            if path and os.path.exists(path):
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
 
-    vis_img = rgb_img.copy()
-    cv2.circle(vis_img, (int(x), int(y)), 8, (0, 0, 255), 2)
-    vis_path = os.path.join(save_dir, f"{timestamp}_pred.jpg")
-    cv2.imwrite(vis_path, vis_img)
+    attempt = 0
+    while True:
+        attempt += 1
+        if attempt > 1:
+            print(
+                f"[INFO] Retrying model-based detection attempt #{attempt} for {target_name}."
+            )
 
-    d_raw = cam.get_depth_point(x, y, depth_img)
-    if d_raw == 0 or d_raw is None:
-        d_raw = cam.get_depth_roi(
-            x,
-            y,
-            depth_img,
-            radius=depth_roi_radius,
-            depth_threshold=depth_threshold,
-            valid_ratio_threshold=valid_ratio_threshold,
+        rgb_img, depth_img = cam.capture_rgbd()
+        if rgb_img is None or depth_img is None:
+            print("[ERROR] Failed to capture RGBD frame.")
+            return None, None, None
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        raw_path = os.path.join(save_dir, f"{timestamp}_rgb.jpg")
+        cv2.imwrite(raw_path, rgb_img)
+
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
+            tmp_path = tmp.name
+        try:
+            cv2.imwrite(tmp_path, rgb_img)
+            with open(tmp_path, "rb") as f:
+                response = requests.post(url, files={"file": f}, timeout=request_timeout)
+            response.raise_for_status()
+            result = response.json()
+            x, y = result.get("x"), result.get("y")
+        except Exception as ex:  # pragma: no cover
+            print(f"[ERROR] Model inference failed: {ex}")
+            return None, None, None
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
+        if x is None or y is None:
+            print("[ERROR] Model failed to detect the target.")
+            return None, None, None
+
+        vis_img = rgb_img.copy()
+        cv2.circle(vis_img, (int(x), int(y)), 8, (0, 0, 255), 2)
+        vis_path = os.path.join(save_dir, f"{timestamp}_pred.jpg")
+        cv2.imwrite(vis_path, vis_img)
+
+        d_raw = cam.get_depth_point(x, y, depth_img)
+        if d_raw == 0 or d_raw is None:
+            d_raw = cam.get_depth_roi(
+                x,
+                y,
+                depth_img,
+                radius=depth_roi_radius,
+                depth_threshold=depth_threshold,
+                valid_ratio_threshold=valid_ratio_threshold,
+            )
+        if d_raw is None:
+            print(
+                f"[WARNING] Detected {target_name} at ({x},{y}), but depth is invalid. Retrying..."
+            )
+            _cleanup_attempt_files(raw_path, vis_path)
+            continue
+
+        X, Y, Z = cam.xy_depth_2_xyz(x, y, d_raw)
+        coords = np.array([X, Y, Z], dtype=float)
+        if not np.all(np.isfinite(coords)):
+            print(
+                f"[WARNING] Detected {target_name} at ({x},{y}), but computed XYZ {coords} contains non-finite values. Retrying..."
+            )
+            _cleanup_attempt_files(raw_path, vis_path)
+            continue
+
+        print(
+            "Model detected {} at pixel ({},{}) -> 3D Coords (X,Y,Z): ({:.4f}, {:.4f}, {:.4f}) m".format(
+                target_name, x, y, X, Y, Z
+            )
         )
-    if d_raw is None:
-        print(f"[ERROR] Detected {target_name} at ({x},{y}), but depth is invalid.")
-        return None, None, None
-
-    X, Y, Z = cam.xy_depth_2_xyz(x, y, d_raw)
-    print(
-        "Model detected {} at pixel ({},{}) -> 3D Coords (X,Y,Z): ({:.4f}, {:.4f}, {:.4f}) m".format(
-            target_name, x, y, X, Y, Z
-        )
-    )
-    print(f"Saved raw image to {raw_path} and prediction to {vis_path}")
-    return X, Y, Z
+        print(f"Saved raw image to {raw_path} and prediction to {vis_path}")
+        return X, Y, Z
 
 
 def detect_top_left_black_center(


### PR DESCRIPTION
## Summary
- add a reusable helper that sends ROS 2 RobotCommand requests from dog_gs
- expose RosBase.send_robot_command and lie_down wrappers that call the StandUpDown service

## Testing
- python -m compileall dog_gs.py

------
https://chatgpt.com/codex/tasks/task_e_68cfd8368a648332b4257d84ddba194d